### PR TITLE
ci: add link checking workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,6 @@
 name: Check Links
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "00 18 * * 0"
@@ -9,11 +8,15 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Check links
+        id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -25,3 +28,11 @@ jobs:
             './config.toml'
           fail: false
           jobSummary: true
+
+      - name: Create issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Broken links report
+          content-filepath: ./lychee/out.md
+          labels: report, broken links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,27 @@
+name: Check Links
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * 0"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --root-dir "${{ github.workspace }}"
+            --verbose
+            --no-progress
+            './**/*.md'
+            './**/*.html'
+            './config.toml'
+          fail: false
+          jobSummary: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       issues: write
@@ -31,8 +31,6 @@ jobs:
 
       - name: Create issue
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: Broken links report
-          content-filepath: ./lychee/out.md
-          labels: report, broken links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue create --title "Broken links report" --body-file ./lychee/out.md

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -33,4 +33,4 @@ jobs:
         if: steps.lychee.outputs.exit_code != 0
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh issue create --title "Broken links report" --body-file ./lychee/out.md
+        run: gh issue create --title "Broken links report ($(date -u +%Y-%m-%d))" --body-file ./lychee/out.md


### PR DESCRIPTION
## Summary
- add a lychee-based GitHub Actions workflow for link checking
- run checks on manual dispatch and a weekly schedule only
- use ubuntu-slim for the runner
- open a dated GitHub issue report with gh issue create when broken links are found
- keep the link-check step non-blocking so reports can be triaged gradually

## Verification
- parsed workflow YAML locally with Ruby