### PR TITLE
ci: align Hugo version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3.2.1
         with:
-          hugo-version: 0.111.3
+          hugo-version: 0.117.0
           extended: true
 
       - name: Build the website


### PR DESCRIPTION
## Summary
- update the GitHub Pages deploy workflow to use Hugo 0.117.0
- align the GitHub Actions Hugo version with the Read the Docs build

## Verification
- parsed GitHub Actions and Read the Docs YAML locally with Ruby