### PR TITLE
fix: make edit link file path explicit

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -11,10 +11,12 @@
 				{{ .Name | safeHTML }}
 			</a>
 			{{ end }}
+			{{ with .File }}
 			<a class="nav-item nav-link active"
-				href="{{ .Site.Params.edit_page.repo_url }}/{{ .Site.Params.edit_page.edit_mode }}/{{ .Site.Params.edit_page.branch }}/{{ .Site.Params.edit_page.repo_dir }}/{{ .File }}">
-				<i class="fas fa-edit"></i> {{ .Site.Params.edit_page.edit_text }}
+				href="{{ $.Site.Params.edit_page.repo_url }}/{{ $.Site.Params.edit_page.edit_mode }}/{{ $.Site.Params.edit_page.branch }}/{{ $.Site.Params.edit_page.repo_dir }}/{{ replace .Path "\\" "/" }}">
+				<i class="fas fa-edit"></i> {{ $.Site.Params.edit_page.edit_text }}
 			</a>
+			{{ end }}
 		</ul>
 	</div>
 </nav>


### PR DESCRIPTION
## Summary
- render the GitHub edit link only for pages with a source file
- use Hugo's explicit .File.Path instead of implicit .File rendering
- normalize path separators before building the GitHub URL

## Verification
- reviewed template diff locally
- could not run Hugo locally because hugo is not installed in this environment