### PR TITLE
feat: render tools from structured data

### DIFF
--- a/RESOURCE_DATA.md
+++ b/RESOURCE_DATA.md
@@ -1,6 +1,6 @@
 # Structured Resource Data
 
-This directory stores structured resource lists rendered by the reusable
+This document describes structured resource lists rendered by the reusable
 `resources` page layout.
 
 ## Page front matter
@@ -22,8 +22,8 @@ thin content page.
 
 ## Data shape
 
-Each data file has top-level `sections`. A section may contain `resources`,
-`groups`, or both.
+Data files live in `data/`. Each data file has top-level `sections`. A section
+may contain `resources`, `groups`, or both.
 
 ```yaml
 sections:

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ baseURL = "https://seismo-learn.org/links/"
 languageCode = "en-us"
 title = "Seismo Links"
 copyright = "&copy; Copyright 2018 - {year}, [seismo-learn](https://seismo-learn.org/). </br> [Contributions](https://github.com/seismo-learn/links#contributing) are welcomed."
-disableKinds = [ "taxonomyTerm", "RSS" ]
+disableKinds = [ "taxonomy", "RSS" ]
 enableGitInfo = true
 
 [params]

--- a/content/tools.md
+++ b/content/tools.md
@@ -1,54 +1,7 @@
 ---
 title: Tools
+layout: resources
+resource_data: tools
+edit_path: data/tools.yaml
 toc: true
 ---
-
-## Science
-
-- [Periodic Table of Elements](https://www.ptable.com)
-- [Animations of the free oscillations of the Earth](https://saviot.cnrs.fr/terre/index.en.html)
-- [IRIS Seismic Monitor](https://www.iris.edu/app/seismic-monitor/map)
-- [IRIS Station Monitor](https://www.iris.edu/app/station_monitor/)
-
-## Computer
-
-- [IPIP](https://www.ipip.net/): The best IP geolocation database
-
-## Programming
-
-### General Tools
-
-- [Choose an open source license](https://choosealicense.com/): Simple way to choose a license
-- [DevDocs](https://devdocs.io/): API documentations of multiple programming languages/tools in one place
-- [regex101](https://regex101.com/): Online regular expressions tester and debugger
-
-### Python
-
-- [strftime](http://strftime.org/): Python strftime reference
-- [ruff](https://github.com/astral-sh/ruff): An extremely fast Python linter and code formatter, written in Rust.
-
-## Document
-
-### Gerneral Tools
-
-- [Convertio](https://convertio.co/): Convert your files to any formats (300+ formats supported)
-- [WebPlotDigitizer](https://automeris.io/WebPlotDigitizer): Web based tool to extract data from plots, images, and maps
-
-### PDF
-
-- [cpdf](http://community.coherentpdf.com/): Command line tool to manipulate existing PDF files
-- [ILovePDF](https://www.ilovepdf.com/): Every tool you need to work with PDFs in one place
-- [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/): The PDF toolkit for doing everyday things with PDF documents
-- [PDF2JPG](https://pdf2jpg.net/): Free PDF to JPG online converter
-- [Smallpdf](https://smallpdf.com/): All-in-one easy-to-use online PDF tools
-
-### Image
-
-- [ILoveIMG](https://www.iloveimg.com/): Every tool you could want to edit images in bulk
-- [Logoly](https://www.logoly.pro/): A simple online logo generator
-- [Squoosh](https://squoosh.app/): Image compression web app provided by Google
-
-## Writing
-
-- [Grammarly](https://www.grammarly.com): Free writing assistant to check your grammar
-- [IRIS citations](https://www.iris.edu/hq/iris_citations): How to cite/acknowledge IRIS data

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,46 @@
+# Structured Resource Data
+
+This directory stores structured resource lists rendered by the reusable
+`resources` page layout.
+
+## Page front matter
+
+Use the `resources` layout and point `resource_data` at a data file name:
+
+```yaml
+---
+title: Tools
+layout: resources
+resource_data: tools
+edit_path: data/tools.yaml
+toc: true
+---
+```
+
+Set `edit_path` so the navbar edit link points to the data file instead of the
+thin content page.
+
+## Data shape
+
+Each data file has top-level `sections`. A section may contain `resources`,
+`groups`, or both.
+
+```yaml
+sections:
+  - title: Science
+    resources:
+      - name: Example Resource
+        url: https://example.com
+        description: Optional short description
+    groups:
+      - title: Subcategory
+        resources:
+          - name: Another Resource
+            url: https://example.org
+```
+
+Resource fields:
+
+- `name`: Display name.
+- `url`: Primary link.
+- `description`: Optional short description.

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -1,0 +1,87 @@
+sections:
+  - title: Science
+    resources:
+      - name: Periodic Table of Elements
+        url: https://www.ptable.com
+      - name: Animations of the free oscillations of the Earth
+        url: https://saviot.cnrs.fr/terre/index.en.html
+      - name: IRIS Seismic Monitor
+        url: https://www.iris.edu/app/seismic-monitor/map
+      - name: IRIS Station Monitor
+        url: https://www.iris.edu/app/station_monitor/
+
+  - title: Computer
+    resources:
+      - name: IPIP
+        url: https://www.ipip.net/
+        description: The best IP geolocation database
+
+  - title: Programming
+    groups:
+      - title: General Tools
+        resources:
+          - name: Choose an open source license
+            url: https://choosealicense.com/
+            description: Simple way to choose a license
+          - name: DevDocs
+            url: https://devdocs.io/
+            description: API documentations of multiple programming languages/tools in one place
+          - name: regex101
+            url: https://regex101.com/
+            description: Online regular expressions tester and debugger
+      - title: Python
+        resources:
+          - name: strftime
+            url: http://strftime.org/
+            description: Python strftime reference
+          - name: ruff
+            url: https://github.com/astral-sh/ruff
+            description: An extremely fast Python linter and code formatter, written in Rust.
+
+  - title: Document
+    groups:
+      - title: General Tools
+        resources:
+          - name: Convertio
+            url: https://convertio.co/
+            description: Convert your files to any formats (300+ formats supported)
+          - name: WebPlotDigitizer
+            url: https://automeris.io/WebPlotDigitizer
+            description: Web based tool to extract data from plots, images, and maps
+      - title: PDF
+        resources:
+          - name: cpdf
+            url: http://community.coherentpdf.com/
+            description: Command line tool to manipulate existing PDF files
+          - name: ILovePDF
+            url: https://www.ilovepdf.com/
+            description: Every tool you need to work with PDFs in one place
+          - name: pdftk
+            url: https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
+            description: The PDF toolkit for doing everyday things with PDF documents
+          - name: PDF2JPG
+            url: https://pdf2jpg.net/
+            description: Free PDF to JPG online converter
+          - name: Smallpdf
+            url: https://smallpdf.com/
+            description: All-in-one easy-to-use online PDF tools
+      - title: Image
+        resources:
+          - name: ILoveIMG
+            url: https://www.iloveimg.com/
+            description: Every tool you could want to edit images in bulk
+          - name: Logoly
+            url: https://www.logoly.pro/
+            description: A simple online logo generator
+          - name: Squoosh
+            url: https://squoosh.app/
+            description: Image compression web app provided by Google
+
+  - title: Writing
+    resources:
+      - name: Grammarly
+        url: https://www.grammarly.com
+        description: Free writing assistant to check your grammar
+      - name: IRIS citations
+        url: https://www.iris.edu/hq/iris_citations
+        description: How to cite/acknowledge IRIS data

--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -1,0 +1,31 @@
+{{ define "main" }}
+{{ $data := index .Site.Data .Params.resource_data }}
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+
+{{ range $data.sections }}
+<h2 id="{{ anchorize .title }}">{{ .title }}</h2>
+  {{ partial "resource_list.html" .resources }}
+  {{ $section := .title }}
+  {{ range .groups }}
+<h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
+    {{ partial "resource_list.html" .resources }}
+  {{ end }}
+{{ end }}
+{{ end }}
+
+{{ define "toc" }}
+{{ $data := index .Site.Data .Params.resource_data }}
+{{ if and .Params.toc $data }}
+<aside>
+  <h2>Table of Contents</h2>
+  <nav id="TableOfContents">
+    <ul>
+    {{ range $data.sections }}
+      <li><a href="#{{ anchorize .title }}">{{ .title }}</a></li>
+    {{ end }}
+    </ul>
+  </nav>
+</aside>
+{{ end }}
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -11,9 +11,17 @@
 				{{ .Name | safeHTML }}
 			</a>
 			{{ end }}
-			{{ with .File }}
+			{{ $editPath := "" }}
+			{{ with .Params.edit_path }}
+				{{ $editPath = . }}
+			{{ else }}
+				{{ with .File }}
+					{{ $editPath = printf "%s/%s" $.Site.Params.edit_page.repo_dir (replace .Path "\\" "/") }}
+				{{ end }}
+			{{ end }}
+			{{ with $editPath }}
 			<a class="nav-item nav-link active"
-				href="{{ $.Site.Params.edit_page.repo_url }}/{{ $.Site.Params.edit_page.edit_mode }}/{{ $.Site.Params.edit_page.branch }}/{{ $.Site.Params.edit_page.repo_dir }}/{{ replace .Path "\\" "/" }}">
+				href="{{ $.Site.Params.edit_page.repo_url }}/{{ $.Site.Params.edit_page.edit_mode }}/{{ $.Site.Params.edit_page.branch }}/{{ . }}">
 				<i class="fas fa-edit"></i> {{ $.Site.Params.edit_page.edit_text }}
 			</a>
 			{{ end }}

--- a/layouts/partials/resource_list.html
+++ b/layouts/partials/resource_list.html
@@ -1,0 +1,9 @@
+{{ with . }}
+<ul>
+{{ range . }}
+  <li>
+    <a href="{{ .url }}">{{ .name }}</a>{{ with .description }}: {{ . | markdownify }}{{ end }}
+  </li>
+{{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
## Summary
- add a reusable resources layout for rendering sectioned resource data
- migrate the Tools page entries from Markdown into data/tools.yaml as a structured-data pilot
- document the resource data shape in RESOURCE_DATA.md
- let pages override the navbar edit target so data-backed pages can link to their data file
- update disableKinds to use Hugo's current taxonomy kind name

## Verification
- parsed data/tools.yaml locally with Ruby
- confirmed the migrated Tools data has 22 resources and no duplicate URLs
- confirmed data/ contains only data/tools.yaml so Hugo will not try to load Markdown as data
- could not run Hugo locally because hugo is not installed in this environment