### PR TITLE
docs: fix visible typos

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
   tools:
     golang: "1.19"  # needed by hugo
   commands:
-    # Full cusotmized build process
+    # Full customized build process
     # https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
     - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.117.0/hugo_extended_0.117.0_Linux-64bit.tar.gz | tar zxvf - hugo
     - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Everyone is welcome to contribute to this site. Contributions include but not li
 For any contributions, please open an [issue](https://github.com/seismo-learn/links/issues)
 or submit a [Pull Request](https://github.com/seismo-learn/links/pulls).
 You could also refer to the [contributing guides](https://seismo-learn.org/contributing/) (in Chinese)
-if you are unfamilar with git, GitHub, Markdown and so on.
+if you are unfamiliar with git, GitHub, Markdown and so on.
 
 
 ## License

--- a/content/codes.md
+++ b/content/codes.md
@@ -35,7 +35,7 @@ toc: true
   [Recipes](https://github.com/seismo-learn/SOD-recipes):
   The best seismic data request tool
 - [ObsPy](https://github.com/obspy/obspy/wiki):
-  Data download, processing and visulization software written in Python
+  Data download, processing and visualization software written in Python
 - [SAC](http://www.iris.edu/ds/nodes/dmc/forms/sac/) |
   [Chinese Manual](https://seisman.github.io/SAC_Docs_zh/) |
   [English Manual](https://ds.iris.edu/files/sac-manual/) |
@@ -58,7 +58,7 @@ toc: true
 - [ObsPy](https://github.com/obspy/obspy) |
   [Waveform Import/Export Plug-ins](https://docs.obspy.org/packages/index.html) |
   [Supported Formats](https://docs.obspy.org/packages/autogen/obspy.core.stream.read.html#obspy.core.stream.read):
-  Data download, processing and visulization software written in Python
+  Data download, processing and visualization software written in Python
 - [SAC](http://www.iris.edu/ds/nodes/dmc/forms/sac/) |
   [Chinese Manual](https://seisman.github.io/SAC_Docs_zh/) |
   [English Manual](https://ds.iris.edu/files/sac-manual/) |
@@ -95,7 +95,7 @@ toc: true
   [notes in Chinese](https://blog.seisman.info/conversion-of-different-sac-formats):
   The most commonly used seismic data processing and plotting software
 - [ObsPy](https://github.com/obspy/obspy/wiki):
-  Data download, processing and visulization software written in Python
+  Data download, processing and visualization software written in Python
 - [CPS330](http://www.eas.slu.edu/eqc/eqccps.html) |
   [A tutorial (in Chinese)](https://seismo-learn.org/software/cps/):
   Collection of programs for calculating theorectical seismogram, receiver function,
@@ -103,7 +103,7 @@ toc: true
 - [Geopsy](http://www.geopsy.org/download.php): An open source software for geophysical
   research and application written in C++
 - [GISMO](http://geoscience-community-codes.github.io/GISMO/):
-  Data download, processing and visulization software written in Matlab
+  Data download, processing and visualization software written in Matlab
 - [hinet_decon](https://github.com/tktmyd/hinet_decon): Deconvolve Hi-net velocity
   record by its seismometer response by using inverse filtering technique
 - [SeisIO.jl](https://github.com/jpjones76/SeisIO.jl):
@@ -129,7 +129,7 @@ toc: true
 - [matplotlib](https://matplotlib.org/): A comprehensive library for creating
   static, animated, and interactive visualizations in Python
 - [ObsPy](https://github.com/obspy/obspy): Data download, processing and
-  visulization software written in Python
+  visualization software written in Python
 - [obspy.imaging.scripts.mopad](https://docs.obspy.org/packages/autogen/obspy.imaging.scripts.mopad.html):
   MoPaD command line utility
 - [MoPad](http://www.larskrieger.de/mopad/) |
@@ -705,7 +705,7 @@ Resources
 - [MCDisp](https://github.com/xin2zhang/MCDisp): Surface wave dispersion inversion
   using Monte Carlo methohd written in Python
 
-### Surfave-wave Tomography Workflow
+### Surface-wave Tomography Workflow
 
 - [seismic-noise-tomography](https://github.com/bgoutorbe/seismic-noise-tomography):
   Python framework for seismic noise tomography
@@ -895,7 +895,7 @@ Resources
 
 - [Fault zone travel time and waveform modelling](https://www.linkresearcher.com/trainings/d65fe2ef-3cc8-4eef-9821-261e3d49a9ae) |
   [bilibili](https://www.bilibili.com/video/av841708479?p=6)
-- [MC3deconv](https://github.com/akuhara/MC3deconv): Bayeisan inversion to recover
+- [MC3deconv](https://github.com/akuhara/MC3deconv): Bayesian inversion to recover
   Green's functions of receiver-side structures from teleseismic waveforms
 
 ### Full Waveform Inversion
@@ -1079,7 +1079,7 @@ Resources
 
 ### Array seismology
 
-- [ObsPy](https://github.com/obspy/obspy): Data download, processing and visulization software written in Python
+- [ObsPy](https://github.com/obspy/obspy): Data download, processing and visualization software written in Python
 - [array_processing](https://github.com/uafgeotools/array_processing):
   Various array processing tools for infrasound and seismic data written in Python
 - [Geopsy](http://www.geopsy.org/download.php): An open source software for geophysical
@@ -1206,7 +1206,7 @@ Resources
 - [distaz](http://www.seis.sc.edu/software/distaz) |
   [A tutorial (in Chinese)](https://seismo-learn.org/software/utilities/distaz/):
   Calculate distance, azimuth and back-azimuth of any two points at the Earth's surface
-- [PlateFlex](https://paudetseis.github.io/PlateFlex/): Estimate lithosphere elstatic
+- [PlateFlex](https://paudetseis.github.io/PlateFlex/): Estimate lithosphere elastic
   thickness written in Python and Fortran
 
 ### Tectonics
@@ -1318,7 +1318,7 @@ Resources
 - [SW3D](http://seis.karlov.mff.cuni.cz/): **S**eismic **W**aves in complex **3D** structures
 - [University of South Carolina Lithospheric Seismology Program](http://www.seis.sc.edu/) |
   [Software](http://www.seis.sc.edu/software.html)
-- [University of Ottawau Geophysics Group](https://www.uogeophysics.com/) |
+- [University of Ottawa Geophysics Group](https://www.uogeophysics.com/) |
   [Software](https://www.uogeophysics.com/#software)
 - [USGS Earthquake Hazards Program](https://www.usgs.gov/natural-hazards/earthquake-hazards) |
   [Software](https://www.usgs.gov/natural-hazards/earthquake-hazards/software)

--- a/content/database.md
+++ b/content/database.md
@@ -73,7 +73,7 @@ toc: true
   Focal mechanism based on JMA Unified Hypocenter Catalog (Preliminary)
 - [NIED Moment Tensors](http://www.fnet.bosai.go.jp/event/joho.php?LANG=en) |
   [Catalog Search](https://www.fnet.bosai.go.jp/event/joho.php?LANG=en)
-- [Northern California Mechanim Catalog](http://www.ncedc.org/ncedc/catalog-search.html)
+- [Northern California Mechanism Catalog](http://www.ncedc.org/ncedc/catalog-search.html)
 - [Southern California Moment Tensor Catalog](http://service.scedc.caltech.edu/eq-catalogs/CMTsearch.php)
 - [European-Mediterranean Seismological Centre Moment Tensors Solutions](https://www.emsc-csem.org/Earthquake/index_tensors.php)
 - [Italy Moment Tensor Catalog](http://cnt.rm.ingv.it/en/tdmt)
@@ -192,7 +192,7 @@ toc: true
 
 ## Seismological Models
 
-### Global and Reginal Reference Seismological Models
+### Global and Regional Reference Seismological Models
 
 - [IRIS Earth Model Collaboration (EMC)](http://ds.iris.edu/ds/products/emc/) |
   [Web Service](http://service.iris.edu/irisws/earth-model/1/)
@@ -218,7 +218,7 @@ toc: true
 - [IRIS EMC: Reference Earth Models](http://ds.iris.edu/ds/products/emc-referencemodels)
 - [TauP: Standard Models](https://www.seis.sc.edu/taup): The **StdModels**
   folder in the source contain a few 1D models (e.g., PREM, AK135, iasp91)
-- [AK135: model, travletime tables, plots and software](http://rses.anu.edu.au/seismology/ak135/intro.html) |
+- [AK135: model, traveltime tables, plots and software](http://rses.anu.edu.au/seismology/ak135/intro.html) |
   [Traveltime tables and ellipticity corrections](http://rses.anu.edu.au/seismology/AK135tables.pdf) with the ellipticity correction method for iasp91
 
 ### 3D Body Wave Tomographic Models

--- a/content/journals.md
+++ b/content/journals.md
@@ -22,7 +22,7 @@ toc: true
     [Archive](https://advances.sciencemag.org/content/by/year)
 - **Proceedings of the National Academy of Sciences (PNAS)**:
     [Homepage](https://www.pnas.org) |
-    [Currnet Issue](https://www.pnas.org/content/current) |
+    [Current Issue](https://www.pnas.org/content/current) |
     [Archive](https://www.pnas.org/content/by/year) |
     [Earth Sciences](https://www.pnas.org/content/by/section/Earth,%20Atmospheric,%20and%20Planetary%20Sciences)
 - **Scientific Reports**:
@@ -108,7 +108,7 @@ toc: true
     [Homepage](https://arxiv.org/) |
     [Geophysics](https://arxiv.org/list/physics.geo-ph/recent)
 
-## Researchers's Academic Profile
+## Researchers' Academic Profile
 
 - [ORCID](https://orcid.org/): A persistent digital identifier for researchers
 - [Google Scholar](https://scholar.google.com/)


### PR DESCRIPTION
## Summary
- fix visible typos in README, Read the Docs config comments, and content pages
- keep changes limited to spelling/word-form corrections

## Verification
- reran typo scan for the corrected terms