### PR TITLE
docs: upgrade safe links to HTTPS

### DIFF
--- a/content/codes.md
+++ b/content/codes.md
@@ -7,27 +7,27 @@ toc: true
 
 ### Data Request Tools
 
-- [FDSN Web Services](http://www.fdsn.org/webservices) |
+- [FDSN Web Services](https://www.fdsn.org/webservices) |
   [A note in Chinese](https://blog.seisman.info/web-service-clients)
 - [IRIS Data Management Center (DMC)](https://ds.iris.edu/ds/nodes/dmc/)
     - [ROVER](https://EarthScope.github.io/rover): A command line tool to robustly
       retrieve geophysical timeseries data from data centers
-    - [BREQ_FAST](http://ds.iris.edu/ds/nodes/dmc/manuals/breq_fast) |
+    - [BREQ_FAST](https://ds.iris.edu/ds/nodes/dmc/manuals/breq_fast) |
       [notes in Chinese](https://blog.seisman.info/tags/breq_fast):
       Seismic data request by sending email
-    - [IRIS Wilber 3](http://ds.iris.edu/wilber3/find_event) |
+    - [IRIS Wilber 3](https://ds.iris.edu/wilber3/find_event) |
       [A note in Chinese](https://blog.seisman.info/wilber3):
       A web GUI to request waveform data of individual seismic events
-    - [jweed](http://ds.iris.edu/ds/nodes/dmc/software/downloads/jweed):
+    - [jweed](https://ds.iris.edu/ds/nodes/dmc/software/downloads/jweed):
       Data request client written in Java
-- [IRIS-DMC: Web Services](http://service.iris.edu):
-  - [clients](http://service.iris.edu/clients/)
+- [IRIS-DMC: Web Services](https://service.iris.edu):
+  - [clients](https://service.iris.edu/clients/)
     - [Web Service Fetch scripts](https://github.com/EarthScope/fetch-scripts)
       [A note in Chinese](https://blog.seisman.info/web-service-fetch-scripts)
-    - [MATLAB data access](http://ds.iris.edu/ds/nodes/dmc/software/downloads/irisFetch.m/)
-  - [FDSNWS](http://service.iris.edu/fdsnws/)
-  - [IRISWS](http://service.iris.edu/irisws/)
-  - [PH5WS](http://service.iris.edu/ph5ws/) |
+    - [MATLAB data access](https://ds.iris.edu/ds/nodes/dmc/software/downloads/irisFetch.m/)
+  - [FDSNWS](https://service.iris.edu/fdsnws/)
+  - [IRISWS](https://service.iris.edu/irisws/)
+  - [PH5WS](https://service.iris.edu/ph5ws/) |
     [Tutorials](https://ds.iris.edu/ds/nodes/dmc/tutorials/accessing-ph5-archive-with-fetchdata/) |
     [wiki](https://github.com/PIC-IRIS/PH5/wiki)
 - [SOD](http://www.seis.sc.edu/sod) |
@@ -36,7 +36,7 @@ toc: true
   The best seismic data request tool
 - [ObsPy](https://github.com/obspy/obspy/wiki):
   Data download, processing and visualization software written in Python
-- [SAC](http://www.iris.edu/ds/nodes/dmc/forms/sac/) |
+- [SAC](https://www.iris.edu/ds/nodes/dmc/forms/sac/) |
   [Chinese Manual](https://seisman.github.io/SAC_Docs_zh/) |
   [English Manual](https://ds.iris.edu/files/sac-manual/) |
   [youtube](https://www.youtube.com/watch?v=zZeUvHkOOAM&list=PLD4D607C2FA317E6D&index=147) |
@@ -59,7 +59,7 @@ toc: true
   [Waveform Import/Export Plug-ins](https://docs.obspy.org/packages/index.html) |
   [Supported Formats](https://docs.obspy.org/packages/autogen/obspy.core.stream.read.html#obspy.core.stream.read):
   Data download, processing and visualization software written in Python
-- [SAC](http://www.iris.edu/ds/nodes/dmc/forms/sac/) |
+- [SAC](https://www.iris.edu/ds/nodes/dmc/forms/sac/) |
   [Chinese Manual](https://seisman.github.io/SAC_Docs_zh/) |
   [English Manual](https://ds.iris.edu/files/sac-manual/) |
   [youtube](https://www.youtube.com/watch?v=zZeUvHkOOAM&list=PLD4D607C2FA317E6D&index=147) |
@@ -82,13 +82,13 @@ toc: true
 - [win32tools](http://www.hinet.bosai.go.jp/REGS/manual/dlDialogue.php?r=win32tools):
   Convert WIN32 format used by Hi-net, to SAC format
 - [rdseed](https://github.com/EarthScope-legacy/rdseed) |
-  [IRIS](http://ds.iris.edu/pub/programs) |
+  [IRIS](https://ds.iris.edu/pub/programs) |
   [notes in Chinese](https://blog.seisman.info/tags/SEED):
   Convert seismic data from SEED format and other formats
 
 ### Seismic Data Processing
 
-- [SAC](http://www.iris.edu/ds/nodes/dmc/forms/sac/) |
+- [SAC](https://www.iris.edu/ds/nodes/dmc/forms/sac/) |
   [Chinese Manual](https://seisman.github.io/SAC_Docs_zh/) |
   [English Manual](https://ds.iris.edu/files/sac-manual/) |
   [youtube](https://www.youtube.com/watch?v=zZeUvHkOOAM&list=PLD4D607C2FA317E6D&index=147) |
@@ -137,12 +137,12 @@ toc: true
   Moment tensor Plotting and Decomposition
 - [3D Focal Mechanisms](https://www.usgs.gov/node/279384):
   View earthquake focal mechanism symbols three dimensionally
-- [EMC-DesktopTools](http://ds.iris.edu/ds/products/emc-desktoptools/)
+- [EMC-DesktopTools](https://ds.iris.edu/ds/products/emc-desktoptools/)
   - [EMC-ParaView](https://github.com/EarthScope/EMC-ParaView): A set of Python
     programmable filters/sources to allow ParaView open-source, multi-platform
     data analysis and visualization application to display EMC netCDF/GeoCSV models
     along with other auxiliary Earth data
-- [EMC visualization tools](http://ds.iris.edu/dms/products/emc/horizontalSlice.html)
+- [EMC visualization tools](https://ds.iris.edu/dms/products/emc/horizontalSlice.html)
 - [SeisTomoPy](https://github.com/stephaniedurand/SeisTomoPy):
   Visulization of 3D tomography models and calculate traveltime in 3D model
 - [SubMachine](https://www.earth.ox.ac.uk/~smachine/cgi/index.php):

--- a/content/database.md
+++ b/content/database.md
@@ -17,8 +17,8 @@ toc: true
 - [中国台网正式地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zhengshi)
 - [European-Mediterranean Seismological Centre Earthquake Catalog](https://www.emsc-csem.org/Earthquake/?filter=yes)
 - [USGS ANSS Comprehensive Earthquake Catalog](https://earthquake.usgs.gov/data/comcat/) |
-  [Catalog Search](http://earthquake.usgs.gov/earthquakes/search/) |
-  [FDSN Event Web Service](http://earthquake.usgs.gov/fdsnws/event/1/) |
+  [Catalog Search](https://earthquake.usgs.gov/earthquakes/search/) |
+  [FDSN Event Web Service](https://earthquake.usgs.gov/fdsnws/event/1/) |
   [Wrapper Libraries](https://www.usgs.gov/software/comcat-wrapper-libraries) |
   [Historic ANSS Composite Catalog](https://ncedc.org/anss/catalog-search.html)
 - [USGS PDE](https://earthquake.usgs.gov/data/comcat/catalog/us/)
@@ -89,14 +89,14 @@ toc: true
 
 ### Global Data Centers/Networks
 
-- [FDSN Network Codes](http://www.fdsn.org/networks/): Network codes assigned by
+- [FDSN Network Codes](https://www.fdsn.org/networks/): Network codes assigned by
   the FDSN to facilitate unique identifiers for seismological data streams
-- [FDSN Web Services: Supporting Data Centers](http://www.fdsn.org/webservices/datacenters/)
+- [FDSN Web Services: Supporting Data Centers](https://www.fdsn.org/webservices/datacenters/)
 - [IRIS DMC](https://ds.iris.edu/ds/nodes/dmc/): IRIS **D**ata **M**anagement **C**enter
-- [IRIS GMap](http://ds.iris.edu/gmap/): Displays networks and stations on an
+- [IRIS GMap](https://ds.iris.edu/gmap/): Displays networks and stations on an
   interactive Google Map
-- [IRIS MDA](http://ds.iris.edu/mda) |
-  [manual](http://ds.iris.edu/ds/nodes/dmc/manuals/mda/):
+- [IRIS MDA](https://ds.iris.edu/mda) |
+  [manual](https://ds.iris.edu/ds/nodes/dmc/manuals/mda/):
   **M**eta**D**ata **A**ggregator provides a browsable list of all networks and stations archived at the IRIS DMC
 - [ORFEUS](http://www.orfeus-eu.org/): **O**bservatories & **R**esearch **F**acilities for **Eu**ropean **S**eismology
 - [CTBTO](https://www.ctbto.org/) | [Web Portal](https://access.ctbto.org/portal/index.html): **C**omprehensive Nuclear-**T**est-**B**an
@@ -144,14 +144,14 @@ toc: true
 ### Analog Seismograms
 
 - [Borovoye Archive Data from Underground Nuclear Tests](https://www.ldeo.columbia.edu/res/pi/Monitoring/Arch/BRV_arch_deglitched.html)
-- [Seismo Archives](http://ds.iris.edu/seismo-archives): Scanned Seismograms
+- [Seismo Archives](https://ds.iris.edu/seismo-archives): Scanned Seismograms
   from Historical Earthquakes
 
 ## Seismological Database
 
 ### Receiver Function
 
-- [IRIS Products: EARS](http://ds.iris.edu/ds/products/ears/):
+- [IRIS Products: EARS](https://ds.iris.edu/ds/products/ears/):
   **E**arthScope **A**utomated **R**eceiver **S**urvey
 - [GLImER](https://www.stephanerondenay.com/glimer-map/map.html): **G**lobal
   **L**ithospheric **Im**aging using **E**arthquake **R**ecordings
@@ -159,7 +159,7 @@ toc: true
 
 ### Shear-wave Splitting
 
-- [IRIS Products: SWS-DBs](http://ds.iris.edu/ds/products/sws-dbs):
+- [IRIS Products: SWS-DBs](https://ds.iris.edu/ds/products/sws-dbs):
   **S**hear-**w**ave **s**plitting **d**ata**b**ase**s**
 - [Automated Splitting Project](http://www.isc.ac.uk/SKS): ISC shear-wave
   splitting database
@@ -168,25 +168,25 @@ toc: true
 
 - [Dispersion Maps](http://ciei.colorado.edu/DispMaps) by University of Colorado, Boulder
 - [Global Dispersion Model GDM52](https://www.ldeo.columbia.edu/~ekstrom/Projects/SWP)
-- [IRIS Products: ANCC-CIEI](http://ds.iris.edu/ds/products/ancc-ciei/):
+- [IRIS Products: ANCC-CIEI](https://ds.iris.edu/ds/products/ancc-ciei/):
   An ambient noise cross-correlation based database of empirical Green's functions
   (EGFs) of the Western US using USArray Transportable Array (TA) data
-- [IRIS Products: Automated Surface Wave Phase Velocity Measuring System (ASWMS)](http://ds.iris.edu/ds/products/aswms):
+- [IRIS Products: Automated Surface Wave Phase Velocity Measuring System (ASWMS)](https://ds.iris.edu/ds/products/aswms):
   USArray and Alaska surface wave tomography maps using ASWMS
 - [USArray Phase-Velocity Maps USANT12](https://www.ldeo.columbia.edu/~ekstrom/Projects/ANT/USANT12.html)
 
 ### Seismic Source Database
 
-- [IRIS Products: Source Time Function](http://ds.iris.edu/ds/products/sourcetimefunction/):
+- [IRIS Products: Source Time Function](https://ds.iris.edu/ds/products/sourcetimefunction/):
   Short-arc Rayleigh wave source-time functions
 
 ### Seismic Data Products
 
-- [IRIS Products: globalstacks](http://ds.iris.edu/ds/products/globalstacks):
+- [IRIS Products: globalstacks](https://ds.iris.edu/ds/products/globalstacks):
   Global stacks of millions of seismograms
-- [IRIS Products: SeisSound](http://ds.iris.edu/ds/products/seissound):
+- [IRIS Products: SeisSound](https://ds.iris.edu/ds/products/seissound):
   The Audio/Video Seismic Waveform Visualization
-- [IRIS Products: ShakeMovieSynthetics](http://ds.iris.edu/ds/products/shakemoviesynthetics):
+- [IRIS Products: ShakeMovieSynthetics](https://ds.iris.edu/ds/products/shakemoviesynthetics):
   1D & 3D synthetic seismograms from the Global ShakeMovie project
 - [European Facilities for Earthquake Hazard and Risk (EFEHR): Services and Partners](http://www.efehr.org/en/efehr/Services-and-Partners)
 
@@ -194,8 +194,8 @@ toc: true
 
 ### Global and Regional Reference Seismological Models
 
-- [IRIS Earth Model Collaboration (EMC)](http://ds.iris.edu/ds/products/emc/) |
-  [Web Service](http://service.iris.edu/irisws/earth-model/1/)
+- [IRIS Earth Model Collaboration (EMC)](https://ds.iris.edu/ds/products/emc/) |
+  [Web Service](https://service.iris.edu/irisws/earth-model/1/)
 - [The Reference Earth Model](https://igppweb.ucsd.edu/~gabi/rem.html)
 - [Crust1.0](https://igppweb.ucsd.edu/~gabi/crust1.html) |
   [Chinese Introduction](https://blog.seisman.info/crust1):
@@ -215,7 +215,7 @@ toc: true
 
 ### 1D Reference Seismological Models
 
-- [IRIS EMC: Reference Earth Models](http://ds.iris.edu/ds/products/emc-referencemodels)
+- [IRIS EMC: Reference Earth Models](https://ds.iris.edu/ds/products/emc-referencemodels)
 - [TauP: Standard Models](https://www.seis.sc.edu/taup): The **StdModels**
   folder in the source contain a few 1D models (e.g., PREM, AK135, iasp91)
 - [AK135: model, traveltime tables, plots and software](http://rses.anu.edu.au/seismology/ak135/intro.html) |

--- a/content/journals.md
+++ b/content/journals.md
@@ -36,18 +36,18 @@ toc: true
     [Current Issue](https://agupubs.onlinelibrary.wiley.com/toc/2576604x/current) |
     [Archive](https://agupubs.onlinelibrary.wiley.com/loi/2576604x)
 - **Annual Review of Earth and Planetary Sciences**:
-    [Homepage](http://www.annualreviews.org/journal/earth) |
+    [Homepage](https://www.annualreviews.org/journal/earth) |
     [Current Issue](https://www.annualreviews.org/toc/earth/current) |
     [Archive](https://www.annualreviews.org/loi/earth)
 - **Earth and Planetary Science Letters**:
     [Homepage](https://www.sciencedirect.com/journal/earth-and-planetary-science-letters) |
     [Archive](https://www.sciencedirect.com/journal/earth-and-planetary-science-letters/issues)
 - **Geochemistry, Geophysics, Geosystems**:
-    [Homepage](http://agupubs.onlinelibrary.wiley.com/hub/journal/10.1002/(ISSN)1525-2027/) |
+    [Homepage](https://agupubs.onlinelibrary.wiley.com/hub/journal/10.1002/(ISSN)1525-2027/) |
     [Current Issue](https://agupubs.onlinelibrary.wiley.com/toc/15252027/current) |
     [Archive](https://agupubs.onlinelibrary.wiley.com/loi/15252027)
 - **Nature GeoScience**:
-    [Homepage](http://www.nature.com/ngeo/index.html) |
+    [Homepage](https://www.nature.com/ngeo/index.html) |
     [Current Issue](https://www.nature.com/ngeo/current-issue) |
     [Archive](https://www.nature.com/ngeo/volumes)
 - **Nature Reviews Earth & Environment**:
@@ -55,7 +55,7 @@ toc: true
     [Current Issue](https://www.nature.com/natrevearthenviron/current-issue) |
     [Archive](https://www.nature.com/natrevearthenviron/volumes/)
 - **Physics of the Earth and Planetary Interiors**:
-    [Homepage](http://www.sciencedirect.com/science/journal/00319201/) |
+    [Homepage](https://www.sciencedirect.com/science/journal/00319201/) |
     [Archive](https://www.sciencedirect.com/journal/physics-of-the-earth-and-planetary-interiors/issues)
 - **Science China Earth Sciences**:
     [Homepage](https://www.springer.com/journal/11430) |
@@ -65,7 +65,7 @@ toc: true
 ## Geophysics Journals
 
 - **Geophysical Journal International**:
-    [Homepage](http://academic.oup.com/gji) |
+    [Homepage](https://academic.oup.com/gji) |
     [Old Archive (1922-1957)](https://academic.oup.com/gsmnras)
 - **Geophysical Research Letters**:
     [Homepage](https://agupubs.onlinelibrary.wiley.com/journal/19448007) |


### PR DESCRIPTION
## Summary
- upgrade a targeted batch of high-confidence HTTP links to HTTPS
- cover FDSN, IRIS/EarthScope service hosts, USGS, and major publisher links
- reduce remaining HTTP references from 276 to 236

## Verification
- confirmed no HTTP links remain for the upgraded host list
- reviewed diff to keep changes limited to URL scheme upgrades