### PR TITLE
docs: upgrade more links to HTTPS

### DIFF
--- a/content/codes.md
+++ b/content/codes.md
@@ -166,7 +166,7 @@ toc: true
   [Tutorials (in Chinese)](https://seismo-learn.org/software/taup/):
   Calculate traveltimes, ray parameters, ray paths, reflection points,
   piercing points of seismic phases, supporting custom Earth models
-- [obspy.taup](http://docs.obspy.org/packages/obspy.taup.html): TauP written in Python
+- [obspy.taup](https://docs.obspy.org/packages/obspy.taup.html): TauP written in Python
 - [ANISOtime](http://www-solid.eps.s.u-tokyo.ac.jp/~dsm/anisotime.html) |
   [GitHub](https://github.com/UT-GlobalSeismology/anisotime):
   Traveltime calculation for transversely isotropic (TI) spherically symmetric models
@@ -882,7 +882,7 @@ Resources
   **F**lat and **I**sotropic **L**ayered structure in the **O**cean
 - [BayHunter](https://github.com/jenndrei/BayHunter): McMC transdimensional Bayesian
   inversion of surface wave dispersion and receiver functions in Python
-- [Huajian Yao: Codes and Software](http://yaolab.ustc.edu.cn/resources.php?i=28):
+- [Huajian Yao: Codes and Software](https://yaolab.ustc.edu.cn/resources.php?i=28):
   Inversion of Vs, Vp/Vs, and interface depth using dispersion data and Rayleigh wave ellipticity
 - [LitMod_seis](https://www.juanafonso.com/software): A joint inversion code
   for inverting Vs and anisotropy

--- a/content/database.md
+++ b/content/database.md
@@ -32,7 +32,7 @@ toc: true
 
 - [中国历史地震目录](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_lsdz):
   公元前 1831 年至公元 1969 年间发生在中国的破坏性地震（M>=4.0）
-- [Japan Meteorological Agency (JMA) Unified Hypocenter Catalog](http://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html)
+- [Japan Meteorological Agency (JMA) Unified Hypocenter Catalog](https://www.data.jma.go.jp/svd/eqev/data/bulletin/hypo_e.html)
 - [JMA Unified Hypocenter Catalog (Preliminary)](https://hinetwww11.bosai.go.jp/auth/JMA/jmalist.php):
   The hypocenters are preliminary results and JMA may revise them
 - [Canada Catalog](https://www.earthquakescanada.nrcan.gc.ca/stndon/NEDB-BNDS/index-en.php) |
@@ -58,7 +58,7 @@ toc: true
 
 ### Focal Mechanism Catalog
 
-- [Global Centroid-Moment-Tensor (CMT)](http://www.globalcmt.org/) |
+- [Global Centroid-Moment-Tensor (CMT)](https://www.globalcmt.org/) |
   [Catalog Search](https://www.globalcmt.org/CMTsearch.html) |
   [Catalog Files](https://www.globalcmt.org/CMTfiles.html)
 - [ISC Focal Mechanism](http://www.isc.ac.uk/iscbulletin/search/fmechanisms/)
@@ -68,13 +68,13 @@ toc: true
 - [Hi-net AUQA Focal Mechanism Catalog](http://www.hinet.bosai.go.jp/AQUA/aqua_catalogue.php?LANG=en)
 - [JMA Seismological Bulletin of Japan](https://www.data.jma.go.jp/svd/eqev/data/bulletin/index_e.html) |
   [CMT Solution](https://www.data.jma.go.jp/svd/eqev/data/bulletin/cmt_e.html) |
-  [Nodal Plane Solution](http://www.data.jma.go.jp/svd/eqev/data/bulletin/mech_e.html)
+  [Nodal Plane Solution](https://www.data.jma.go.jp/svd/eqev/data/bulletin/mech_e.html)
 - [JMA Focal Mechanism Catalog](https://hinetwww11.bosai.go.jp/auth/JMA/?LANG=en):
   Focal mechanism based on JMA Unified Hypocenter Catalog (Preliminary)
-- [NIED Moment Tensors](http://www.fnet.bosai.go.jp/event/joho.php?LANG=en) |
+- [NIED Moment Tensors](https://www.fnet.bosai.go.jp/event/joho.php?LANG=en) |
   [Catalog Search](https://www.fnet.bosai.go.jp/event/joho.php?LANG=en)
 - [Northern California Mechanism Catalog](http://www.ncedc.org/ncedc/catalog-search.html)
-- [Southern California Moment Tensor Catalog](http://service.scedc.caltech.edu/eq-catalogs/CMTsearch.php)
+- [Southern California Moment Tensor Catalog](https://service.scedc.caltech.edu/eq-catalogs/CMTsearch.php)
 - [European-Mediterranean Seismological Centre Moment Tensors Solutions](https://www.emsc-csem.org/Earthquake/index_tensors.php)
 - [Italy Moment Tensor Catalog](http://cnt.rm.ingv.it/en/tdmt)
 
@@ -83,7 +83,7 @@ toc: true
 - [ISC Arrival Time Data](http://www.isc.ac.uk/iscbulletin/search/arrivals/)
 - [中国台网震相数据](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_zgtwzx)
 - [中国国家台网震相数据](https://data.earthquake.cn/datashare/report.shtml?PAGEID=earthquake_gjtwzx)
-- [JMA Arrival Time Data](http://www.data.jma.go.jp/svd/eqev/data/bulletin/deck_e.html)
+- [JMA Arrival Time Data](https://www.data.jma.go.jp/svd/eqev/data/bulletin/deck_e.html)
 
 ## Seismic Data Centers/Networks
 
@@ -114,7 +114,7 @@ toc: true
 - [台灣地震科學中心](https://tec.earth.sinica.edu.tw/index.php) |
   [資料中心](http://tecdc.earth.sinica.edu.tw/tecdc/)
 - [台灣中央研究院地球科學研究所：强震和移动地震台网](https://www.earth.sinica.edu.tw/content/labs/slab/smdmc/index.htm)
-- [Hi-net](http://www.hinet.bosai.go.jp/) | [F-net](http://www.fnet.bosai.go.jp/) |
+- [Hi-net](http://www.hinet.bosai.go.jp/) | [F-net](https://www.fnet.bosai.go.jp/) |
   [K-net, KiK-net](http://www.kyoshin.bosai.go.jp/):
   National Research Institute for Earth Science and Disaster Resilience (NIED) networks
 - [OHP DMC](http://ohpdmc.eri.u-tokyo.ac.jp/):
@@ -125,7 +125,7 @@ toc: true
 - [Alaska Earthquake Center](http://earthquake.alaska.edu/)
 - [Northern California Earthquake Data Center](http://www.ncedc.org/)
 - [Southern California Seismic Network](http://www.scsn.org) |
-  [Southern California Earthquake Data Center](http://scedc.caltech.edu/)
+  [Southern California Earthquake Data Center](https://scedc.caltech.edu/)
 - [Pacific Northwest Seismic Network](http://pnsn.org/)
 - [Canadian Seismic Stations and Data](https://www.earthquakescanada.nrcan.gc.ca/stndon/index-en.php)
 

--- a/content/journals.md
+++ b/content/journals.md
@@ -6,7 +6,7 @@ toc: true
 ## Multidisciplinary Journals
 
 - **Science**:
-    [Homepage](http://science.sciencemag.org/) |
+    [Homepage](https://science.sciencemag.org/) |
     [Current Issue](https://science.sciencemag.org/content/current) |
     [Archive](https://science.sciencemag.org/content/by/year)
 - **Nature**:
@@ -18,7 +18,7 @@ toc: true
     [Homepage](https://www.nature.com/ncomms/) |
     [Earth Sciences](https://www.nature.com/subjects/earth-and-environmental-sciences/ncomms)
 - **Science Advances**:
-    [Homepage](http://advances.sciencemag.org/) |
+    [Homepage](https://advances.sciencemag.org/) |
     [Archive](https://advances.sciencemag.org/content/by/year)
 - **Proceedings of the National Academy of Sciences (PNAS)**:
     [Homepage](https://www.pnas.org) |


### PR DESCRIPTION
## Summary
- upgrade another targeted set of HTTP links to HTTPS
- limit this batch to hosts that already appear elsewhere in the repo with HTTPS links
- reduce remaining HTTP references from 236 to 225

## Verification
- confirmed no HTTP links remain for the upgraded host list
- reviewed diff to keep changes limited to URL scheme upgrades