### PR TITLE
style: improve mobile table of contents

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -50,3 +50,12 @@ aside {
     padding: 20px;
     width: auto;
 }
+
+@media (max-width: 48em) {
+    aside {
+        clear: both;
+        display: block;
+        float: none;
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- make the table-of-contents aside full-width on narrow screens
- clear the desktop float on mobile to avoid cramped/overflowing content

## Verification
- reviewed CSS diff locally
- could not run Hugo locally because hugo is not installed in this environment