### PR TITLE
docs: align local serve command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	@hugo
 
 serve:
-	hugo server
+	hugo server --baseURL http://localhost:1313/links/ --appendPort=false
 
 clean:
 	rm -rf public resources

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build it locally, you need to follow the steps below:
     http://localhost:1313/links/ in your local web browser.
 
     ```
-    $ hugo server
+    $ make serve
     ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- update make serve to serve the site at http://localhost:1313/links/
- update README local build instructions to recommend make serve

## Verification
- reviewed Makefile and README diff locally
- could not run Hugo locally because hugo is not installed in this environment