### PR TITLE
build: update CDN asset versions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,14 +13,14 @@ lastupdate = "Built by [Hugo](https://gohugo.io/) on {now}."
 
   [params.assets]
   bootstrap_cdn = "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap"
-  bootstrap_version = "4.6.0"
+  bootstrap_version = "4.6.2"
   bootswatch_cdn = "https://cdnjs.cloudflare.com/ajax/libs/bootswatch"
-  bootswatch_version = "4.6.0"
+  bootswatch_version = "4.6.2"
   bootswatch_theme = "cosmo"
   fontawesome_cdn = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome"
-  fontawesome_version = "5.15.3"
+  fontawesome_version = "5.15.4"
   jquery_cdn = "https://cdnjs.cloudflare.com/ajax/libs/jquery"
-  jquery_version = "3.6.0"
+  jquery_version = "3.7.1"
 
   [params.edit_page]
   repo_url = "https://github.com/seismo-learn/links"


### PR DESCRIPTION
## Summary
- update Bootstrap and Bootswatch from 4.6.0 to 4.6.2
- update Font Awesome from 5.15.3 to 5.15.4
- update jQuery from 3.6.0 to 3.7.1

## Verification
- reviewed config/template usage locally
- could not run Hugo locally because hugo is not installed in this environment