### PR TITLE
feat: render jobs from structured data

### DIFF
--- a/content/jobs.md
+++ b/content/jobs.md
@@ -1,25 +1,6 @@
 ---
 title: Jobs
+layout: resources
+resource_data: jobs
+edit_path: data/jobs.yaml
 ---
-
-### Job Boards
-
-- [Incorporated Research Institutions for Seismology (IRIS) Job Announcements](https://groups.google.com/a/earthscope.org/g/jobs)
-- [American Geophysical Union (AGU) Career Center](https://findajob.agu.org/)
-- [Computational Infrastructure for Geodynamics (CIG) Jobs Postings](https://community.geodynamics.org/c/job-postings/)
-- [EarthWorks Jobs](https://www.earthworks-jobs.com)
-- [European Geosciences Union (EGU) Jobs](https://www.egu.eu/jobs/)
-- [Geological Society of America (GSA) Geoscience Job Board](http://www.geosociety.org/GSA/Publications/GSA_Today/Job_Board/GSA/GSAToday/Job_Board.aspx)
-- [Japan Society for the Promotion of Science (JSPS) Postdoctoral Fellowships](https://www.jsps.go.jp/english/e-fellow/index.html)
-- [Seismological Society of America (SSA) Job Listings](https://www.seismosoc.org/jobs/job-listings/)
-- [THEunijobs](https://www.timeshighereducation.com/unijobs/en-us/): International university and academic jobs
-
-### University/Institution Jobs
-
-- [Caltech Academic Positions and Opportunities](https://applications.caltech.edu)
-- [Carnegie Institution for Science Jobs Listing](https://jobs.carnegiescience.edu/jobs)
-- [Institute for Geophysics at University of Texas Institute Job Listings](https://ig.utexas.edu/about/job-listings)
-- [Lamont-Doherty Earth Observatory at Columbia University Postdoctoral Fellowships](https://www.ldeo.columbia.edu/about-ldeo/office-director/postdoc-applications)
-- [Nanyang Technological University Jobs](https://www.ntu.edu.sg/research/research-careers)
-- [Scripps Institution of Oceanography at UC San Diego Jobs](https://scripps.ucsd.edu/portal/jobs)
-- [U.S. Geological Survey (USGS) Mendenhall Research Fellowship Program](https://www.usgs.gov/centers/mendenhall)

--- a/data/jobs.yaml
+++ b/data/jobs.yaml
@@ -1,0 +1,39 @@
+sections:
+  - title: Job Boards
+    resources:
+      - name: Incorporated Research Institutions for Seismology (IRIS) Job Announcements
+        url: https://groups.google.com/a/earthscope.org/g/jobs
+      - name: American Geophysical Union (AGU) Career Center
+        url: https://findajob.agu.org/
+      - name: Computational Infrastructure for Geodynamics (CIG) Jobs Postings
+        url: https://community.geodynamics.org/c/job-postings/
+      - name: EarthWorks Jobs
+        url: https://www.earthworks-jobs.com
+      - name: European Geosciences Union (EGU) Jobs
+        url: https://www.egu.eu/jobs/
+      - name: Geological Society of America (GSA) Geoscience Job Board
+        url: http://www.geosociety.org/GSA/Publications/GSA_Today/Job_Board/GSA/GSAToday/Job_Board.aspx
+      - name: Japan Society for the Promotion of Science (JSPS) Postdoctoral Fellowships
+        url: https://www.jsps.go.jp/english/e-fellow/index.html
+      - name: Seismological Society of America (SSA) Job Listings
+        url: https://www.seismosoc.org/jobs/job-listings/
+      - name: THEunijobs
+        url: https://www.timeshighereducation.com/unijobs/en-us/
+        description: International university and academic jobs
+
+  - title: University/Institution Jobs
+    resources:
+      - name: Caltech Academic Positions and Opportunities
+        url: https://applications.caltech.edu
+      - name: Carnegie Institution for Science Jobs Listing
+        url: https://jobs.carnegiescience.edu/jobs
+      - name: Institute for Geophysics at University of Texas Institute Job Listings
+        url: https://ig.utexas.edu/about/job-listings
+      - name: Lamont-Doherty Earth Observatory at Columbia University Postdoctoral Fellowships
+        url: https://www.ldeo.columbia.edu/about-ldeo/office-director/postdoc-applications
+      - name: Nanyang Technological University Jobs
+        url: https://www.ntu.edu.sg/research/research-careers
+      - name: Scripps Institution of Oceanography at UC San Diego Jobs
+        url: https://scripps.ucsd.edu/portal/jobs
+      - name: U.S. Geological Survey (USGS) Mendenhall Research Fellowship Program
+        url: https://www.usgs.gov/centers/mendenhall


### PR DESCRIPTION
## Summary
- migrate the Jobs page entries into data/jobs.yaml
- render Jobs with the existing reusable resources layout
- point the page edit link at the new data file

## Verification
- parsed data/jobs.yaml locally with Ruby
- confirmed the migrated Jobs data has 2 sections, 16 resources, and no duplicate URLs
- could not run Hugo locally because hugo is not installed in this environment