### PR TITLE
style: simplify homepage card links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,13 +3,11 @@
 <div class="card-columns mt-4">
 {{ range .Params.cards }}
 	<div class="card text-center">
-		<div class="card-body" onclick="location.href = '{{ .link }}'">
-			<p class="card-text">
-				<a href="{{ .link | absURL }}" target="_self" class="iconLink">
-					<i class="fas {{ .icon }} fa-5x"></i>
-					<h5 class='card-title'>{{ .name }}</h5>
-				</a>
-			</p>
+		<div class="card-body">
+			<i class="fas {{ .icon }} fa-5x"></i>
+			<h5 class="card-title">
+				<a href="{{ .link | relURL }}" class="iconLink stretched-link">{{ .name }}</a>
+			</h5>
 		</div>
 	</div>
 {{ end }}

--- a/static/main.css
+++ b/static/main.css
@@ -30,6 +30,16 @@ footer {
   background-color: aliceblue;
 }
 
+.card-columns .card-body {
+  position: relative;
+}
+
+.iconLink,
+.iconLink:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
 .navbar {
   background-color: aqua;
   border-bottom-left-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- remove the inline onclick handler from homepage cards
- use a normal stretched link for card navigation
- clean up card markup by avoiding a heading nested inside a paragraph

## Verification
- reviewed template and CSS diff locally
- confirmed no inline onclick handlers remain
- could not run Hugo locally because hugo is not installed in this environment