### PR TITLE
build: bump Hugo to 0.162.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3.2.1
         with:
-          hugo-version: 0.117.0
+          hugo-version: 0.162.1
           extended: true
 
       - name: Build the website

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ build:
   commands:
     # Full customized build process
     # https://docs.readthedocs.io/en/stable/build-customization.html#override-the-build-process
-    - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.117.0/hugo_extended_0.117.0_Linux-64bit.tar.gz | tar zxvf - hugo
+    - curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.162.1/hugo_extended_0.162.1_Linux-64bit.tar.gz | tar zxvf - hugo
     - sed -i "s#https://seismo-learn.org/links/#${READTHEDOCS_CANONICAL_URL}#" config.toml
     - ./hugo -d $READTHEDOCS_OUTPUT/html/


### PR DESCRIPTION
## Summary
- update the GitHub Actions Hugo version to 0.162.1
- update the Read the Docs Hugo download URL to 0.162.1
- keep both build paths aligned on the same Hugo release

## Verification
- checked Hugo's official release listing for the latest release
- parsed GitHub Actions and Read the Docs YAML locally with Ruby
- could not run Hugo locally because hugo is not installed in this environment