### PR TITLE
refactor: validate resource data lookup

### DIFF
--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ $data := index .Site.Data .Params.resource_data }}
+{{ $data := partial "resource_data.html" . }}
 <h1>{{ .Title }}</h1>
 {{ .Content }}
 
@@ -15,7 +15,7 @@
 {{ end }}
 
 {{ define "toc" }}
-{{ $data := index .Site.Data .Params.resource_data }}
+{{ $data := partial "resource_data.html" . }}
 {{ if and .Params.toc $data }}
 <aside>
   <h2>Table of Contents</h2>

--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -22,7 +22,17 @@
   <nav id="TableOfContents">
     <ul>
     {{ range $data.sections }}
-      <li><a href="#{{ anchorize .title }}">{{ .title }}</a></li>
+      <li>
+        <a href="#{{ anchorize .title }}">{{ .title }}</a>
+        {{ $section := .title }}
+        {{ with .groups }}
+        <ul>
+          {{ range . }}
+          <li><a href="#{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</a></li>
+          {{ end }}
+        </ul>
+        {{ end }}
+      </li>
     {{ end }}
     </ul>
   </nav>

--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -4,13 +4,7 @@
 {{ .Content }}
 
 {{ range $data.sections }}
-<h2 id="{{ anchorize .title }}">{{ .title }}</h2>
-  {{ partial "resource_list.html" .resources }}
-  {{ $section := .title }}
-  {{ range .groups }}
-<h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
-    {{ partial "resource_list.html" .resources }}
-  {{ end }}
+{{ partial "resource_section.html" . }}
 {{ end }}
 {{ end }}
 

--- a/layouts/partials/resource_data.html
+++ b/layouts/partials/resource_data.html
@@ -1,0 +1,11 @@
+{{ $name := .Params.resource_data }}
+{{ if not $name }}
+  {{ errorf "resources layout requires resource_data in front matter for %q" .File.Path }}
+{{ end }}
+
+{{ $data := index .Site.Data $name }}
+{{ if not $data }}
+  {{ errorf "resources layout could not find data file for resource_data=%q in %q" $name .File.Path }}
+{{ end }}
+
+{{ return $data }}

--- a/layouts/partials/resource_section.html
+++ b/layouts/partials/resource_section.html
@@ -1,0 +1,7 @@
+<h2 id="{{ anchorize .title }}">{{ .title }}</h2>
+{{ partial "resource_list.html" .resources }}
+{{ $section := .title }}
+{{ range .groups }}
+<h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
+  {{ partial "resource_list.html" .resources }}
+{{ end }}


### PR DESCRIPTION
## Summary
- add a resource_data partial to centralize data-backed page lookup
- emit explicit Hugo build errors when resource_data is missing or points to unknown data
- reuse the helper in both the resources main content and TOC blocks
- include resource groups in generated TOCs for data-backed pages
- extract section rendering into a resource_section partial

## Verification
- reviewed template diffs locally
- could not run Hugo locally because hugo is not installed in this environment