### PR TITLE
feat: improve tools page layout

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Tools
-layout: resources
+layout: tools
 resource_data: tools
 edit_path: data/tools.yaml
 toc: true

--- a/layouts/_default/tools.html
+++ b/layouts/_default/tools.html
@@ -1,0 +1,56 @@
+{{ define "main" }}
+{{ $data := partial "resource_data.html" . }}
+<div class="tools-page">
+  <header class="tools-header">
+    <h1>{{ .Title }}</h1>
+    {{ .Content }}
+  </header>
+
+  <div class="tools-grid">
+    {{ range $data.sections }}
+    {{ $sectionCount := len (default (slice) .resources) }}
+    {{ range .groups }}
+      {{ $sectionCount = add $sectionCount (len (default (slice) .resources)) }}
+    {{ end }}
+    <section class="tools-section" aria-labelledby="{{ anchorize .title }}">
+      <div class="tools-section-heading">
+        <h2 id="{{ anchorize .title }}">{{ .title }}</h2>
+        <span>{{ $sectionCount }} {{ cond (eq $sectionCount 1) "tool" "tools" }}</span>
+      </div>
+
+      {{ partial "tools_resource_cards.html" .resources }}
+
+      {{ $section := .title }}
+      {{ range .groups }}
+      <div class="tools-group">
+        <h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
+        {{ partial "tools_resource_cards.html" .resources }}
+      </div>
+      {{ end }}
+    </section>
+    {{ end }}
+  </div>
+</div>
+{{ end }}
+
+{{ define "toc" }}
+{{ $data := partial "resource_data.html" . }}
+{{ if and .Params.toc $data }}
+<aside class="tools-toc">
+  <h2>Categories</h2>
+  <nav id="TableOfContents">
+    <ul>
+    {{ range $data.sections }}
+      {{ $sectionCount := len (default (slice) .resources) }}
+      {{ range .groups }}
+        {{ $sectionCount = add $sectionCount (len (default (slice) .resources)) }}
+      {{ end }}
+      <li>
+        <a href="#{{ anchorize .title }}">{{ .title }} <span>{{ $sectionCount }}</span></a>
+      </li>
+    {{ end }}
+    </ul>
+  </nav>
+</aside>
+{{ end }}
+{{ end }}

--- a/layouts/partials/tools_resource_cards.html
+++ b/layouts/partials/tools_resource_cards.html
@@ -1,0 +1,21 @@
+{{ with . }}
+<div class="tools-cards">
+{{ range . }}
+  <article class="tool-card">
+    <div class="tool-card-title">
+      {{ if .url }}
+      <a href="{{ .url }}">{{ .name }}</a>
+      {{ else }}
+      <strong>{{ .name }}</strong>
+      {{ end }}
+    </div>
+    {{ with .description }}<p>{{ . | markdownify }}</p>{{ end }}
+    {{ with .links }}
+    <div class="tool-card-links" aria-label="Related links">
+      {{ range . }}<a href="{{ .url }}">{{ .name }}</a>{{ end }}
+    </div>
+    {{ end }}
+  </article>
+{{ end }}
+</div>
+{{ end }}

--- a/static/main.css
+++ b/static/main.css
@@ -69,3 +69,115 @@ aside {
         width: 100%;
     }
 }
+
+.tools-page {
+    --tools-border: #d7dee8;
+    --tools-muted: #5c6675;
+    --tools-surface: #f8fafc;
+}
+
+.tools-header {
+    margin-bottom: 1.5rem;
+}
+
+.tools-grid {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.tools-section {
+    border-top: 1px solid var(--tools-border);
+    padding-top: 1rem;
+}
+
+.tools-section-heading {
+    align-items: baseline;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+}
+
+.tools-section-heading h2 {
+    margin: 0;
+}
+
+.tools-section-heading span,
+.tools-toc a span {
+    color: var(--tools-muted);
+    font-size: 0.875rem;
+    white-space: nowrap;
+}
+
+.tools-group {
+    margin-top: 1rem;
+}
+
+.tools-group h3 {
+    color: var(--tools-muted);
+    font-size: 1rem;
+    letter-spacing: 0;
+    margin-bottom: 0.5rem;
+}
+
+.tools-cards {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.tool-card {
+    background: var(--tools-surface);
+    border: 1px solid var(--tools-border);
+    border-radius: 0.5rem;
+    margin: 0;
+    padding: 0.85rem;
+}
+
+.tool-card-title {
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.tool-card p {
+    color: var(--tools-muted);
+    font-size: 0.95rem;
+    margin: 0.35rem 0 0;
+}
+
+.tool-card-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.75rem;
+    margin-top: 0.6rem;
+}
+
+.tool-card-links a {
+    font-size: 0.9rem;
+}
+
+.tools-toc {
+    padding: 1rem;
+}
+
+.tools-toc h2 {
+    font-size: 1rem;
+    margin-top: 0;
+}
+
+.tools-toc ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.tools-toc li + li {
+    margin-top: 0.4rem;
+}
+
+.tools-toc a {
+    align-items: baseline;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- add a dedicated tools page layout with compact resource cards
- show per-category tool counts in the sidebar and section headings
- keep the shared resources layout unchanged for the larger resource pages

## Checks
- git diff --check
- parsed data/tools.yaml and verified category counts

Note: local make build could not run because hugo is not installed in this environment.