### PR TITLE
build: fix Hugo deprecations

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 # Hugo configuration file
 #
 baseURL = "https://seismo-learn.org/links/"
-languageCode = "en-us"
+locale = "en-us"
 title = "Seismo Links"
 copyright = "&copy; Copyright 2018 - {year}, [seismo-learn](https://seismo-learn.org/). </br> [Contributions](https://github.com/seismo-learn/links#contributing) are welcomed."
 disableKinds = [ "taxonomy", "RSS" ]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode | default "en-us" }}">
+<html lang="{{ .Site.Language.Locale | default "en-us" }}">
   {{ partial "site_head" . }}
   <body>
     <main class="container">

--- a/layouts/partials/resource_data.html
+++ b/layouts/partials/resource_data.html
@@ -3,7 +3,7 @@
   {{ errorf "resources layout requires resource_data in front matter for %q" .File.Path }}
 {{ end }}
 
-{{ $data := index .Site.Data $name }}
+{{ $data := index hugo.Data $name }}
 {{ if not $data }}
   {{ errorf "resources layout could not find data file for resource_data=%q in %q" $name .File.Path }}
 {{ end }}


### PR DESCRIPTION
## Summary
- replace deprecated languageCode config usage with locale
- update the base layout to use .Site.Language.Locale
- switch resource data lookup from .Site.Data to hugo.Data

## Checks
- make build passes with Hugo 0.162.1 and no deprecation warnings
- git diff --check
