### PR TITLE
refactor: collapse resource toc by default

### DIFF
--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -87,24 +87,26 @@ document.addEventListener("DOMContentLoaded", function () {
 {{ $data := partial "resource_data.html" . }}
 {{ if and .Params.toc $data }}
 <aside>
-  <h2>Table of Contents</h2>
-  <nav id="TableOfContents">
-    <ul>
-    {{ range $data.sections }}
-      <li>
-        <a href="#{{ anchorize .title }}">{{ .title }}</a>
-        {{ $section := .title }}
-        {{ with .groups }}
-        <ul>
-          {{ range . }}
-          <li><a href="#{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</a></li>
+  <details class="resource-toc">
+    <summary>Table of Contents</summary>
+    <nav id="TableOfContents">
+      <ul>
+      {{ range $data.sections }}
+        <li>
+          <a href="#{{ anchorize .title }}">{{ .title }}</a>
+          {{ $section := .title }}
+          {{ with .groups }}
+          <ul>
+            {{ range . }}
+            <li><a href="#{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</a></li>
+            {{ end }}
+          </ul>
           {{ end }}
-        </ul>
-        {{ end }}
-      </li>
-    {{ end }}
-    </ul>
-  </nav>
+        </li>
+      {{ end }}
+      </ul>
+    </nav>
+  </details>
 </aside>
 {{ end }}
 {{ end }}

--- a/static/main.css
+++ b/static/main.css
@@ -71,14 +71,42 @@ aside {
 }
 
 .resource-toc summary {
+    align-items: center;
+    background: #eef3f8;
+    border: 1px solid #d6dde6;
+    border-radius: 0.375rem;
     cursor: pointer;
+    display: flex;
     font-size: 1rem;
     font-weight: 600;
+    justify-content: space-between;
     margin-bottom: 0.25rem;
+    min-height: 2.75rem;
+    padding: 0.6rem 0.85rem;
+}
+
+.resource-toc summary:hover {
+    background: #e6edf5;
+}
+
+.resource-toc summary:focus {
+    outline: 2px solid #7aa7d8;
+    outline-offset: 2px;
+}
+
+.resource-toc summary::after {
+    content: "+";
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: 1;
 }
 
 .resource-toc[open] summary {
     margin-bottom: 0.75rem;
+}
+
+.resource-toc[open] summary::after {
+    content: "-";
 }
 
 .resource-search {

--- a/static/main.css
+++ b/static/main.css
@@ -70,6 +70,17 @@ aside {
     }
 }
 
+.resource-toc summary {
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.resource-toc[open] summary {
+    margin-bottom: 0.75rem;
+}
+
 .resource-search {
     background: #f5f8fb;
     border: 1px solid #d6dde6;


### PR DESCRIPTION
## Summary
- collapse the shared resource-page table of contents by default
- keep the TOC available for category browsing via a details/summary toggle
- add a small style touch so the collapsed control reads clearly

## Checks
- make build
- git diff --check
