### PR TITLE
feat: improve resource page layout

### DIFF
--- a/layouts/partials/resource_list.html
+++ b/layouts/partials/resource_list.html
@@ -1,19 +1,25 @@
 {{ with . }}
-<ul>
+<ul class="resource-list">
 {{ range . }}
   {{ $searchText := printf "%s %s" .name (.description | default "") }}
   {{ range (.links | default (slice)) }}
     {{ $searchText = printf "%s %s %s" $searchText .name .url }}
   {{ end }}
-  <li data-resource-entry data-search-text="{{ lower ($searchText | plainify) }}">
-    {{ if .url }}
-    <a href="{{ .url }}">{{ .name }}</a>
-    {{ else }}
-    <strong>{{ .name }}</strong>
+  <li class="resource-entry" data-resource-entry data-search-text="{{ lower ($searchText | plainify) }}">
+    <div class="resource-entry-title">
+      {{ if .url }}
+      <a href="{{ .url }}">{{ .name }}</a>
+      {{ else }}
+      <strong>{{ .name }}</strong>
+      {{ end }}
+    </div>
+    {{ with .description }}
+    <p class="resource-entry-description">{{ . | markdownify }}</p>
     {{ end }}
-    {{ with .description }}: {{ . | markdownify }}{{ end }}
-    {{ with .links }}:
-      {{ range $index, $link := . }}{{ if $index }} | {{ end }}<a href="{{ $link.url }}">{{ $link.name }}</a>{{ end }}
+    {{ with .links }}
+    <div class="resource-entry-links" aria-label="Related links">
+      {{ range . }}<a href="{{ .url }}">{{ .name }}</a>{{ end }}
+    </div>
     {{ end }}
   </li>
 {{ end }}

--- a/layouts/partials/resource_list.html
+++ b/layouts/partials/resource_list.html
@@ -6,20 +6,22 @@
     {{ $searchText = printf "%s %s %s" $searchText .name .url }}
   {{ end }}
   <li class="resource-entry" data-resource-entry data-search-text="{{ lower ($searchText | plainify) }}">
-    <div class="resource-entry-title">
+    <div class="resource-entry-main">
+      <div class="resource-entry-title">
       {{ if .url }}
       <a href="{{ .url }}">{{ .name }}</a>
       {{ else }}
       <strong>{{ .name }}</strong>
       {{ end }}
+      </div>
+      {{ with .links }}
+      <div class="resource-entry-links" aria-label="Related links">
+        {{ range . }}<a href="{{ .url }}">{{ .name }}</a>{{ end }}
+      </div>
+      {{ end }}
     </div>
     {{ with .description }}
     <p class="resource-entry-description">{{ . | markdownify }}</p>
-    {{ end }}
-    {{ with .links }}
-    <div class="resource-entry-links" aria-label="Related links">
-      {{ range . }}<a href="{{ .url }}">{{ .name }}</a>{{ end }}
-    </div>
     {{ end }}
   </li>
 {{ end }}

--- a/layouts/partials/resource_section.html
+++ b/layouts/partials/resource_section.html
@@ -1,10 +1,10 @@
 <section class="resource-section" data-resource-section>
-<h2 id="{{ anchorize .title }}">{{ .title }}</h2>
+<h2 class="resource-section-title" id="{{ anchorize .title }}">{{ .title }}</h2>
 {{ partial "resource_list.html" .resources }}
 {{ $section := .title }}
 {{ range .groups }}
 <div class="resource-group" data-resource-group>
-<h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
+<h3 class="resource-group-title" id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
   {{ partial "resource_list.html" .resources }}
   </div>
 {{ end }}

--- a/static/main.css
+++ b/static/main.css
@@ -147,11 +147,71 @@ aside {
 }
 
 .resource-page .resource-section + .resource-section {
-    margin-top: 1.5rem;
+    margin-top: 2rem;
+}
+
+.resource-section {
+    border-top: 1px solid #dde5ee;
+    padding-top: 1.25rem;
+}
+
+.resource-section-title {
+    margin-bottom: 1rem;
 }
 
 .resource-group {
-    margin-top: 1rem;
+    margin-top: 1.5rem;
+}
+
+.resource-group-title {
+    color: #5c6675;
+    font-size: 1.05rem;
+    margin-bottom: 0.75rem;
+}
+
+.resource-list {
+    display: grid;
+    gap: 0.85rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.resource-entry {
+    background: #f8fafc;
+    border: 1px solid #d9e1ea;
+    border-radius: 0.5rem;
+    padding: 0.9rem 1rem;
+}
+
+.resource-entry-title {
+    font-size: 1.02rem;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.resource-entry-description {
+    color: #5c6675;
+    margin: 0.45rem 0 0;
+}
+
+.resource-entry-description p {
+    margin: 0;
+}
+
+.resource-entry-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem 0.8rem;
+    margin-top: 0.7rem;
+}
+
+.resource-entry-links a {
+    background: #eef3f8;
+    border: 1px solid #d6dde6;
+    border-radius: 999px;
+    font-size: 0.92rem;
+    padding: 0.2rem 0.6rem;
 }
 
 li[data-resource-entry][hidden],

--- a/static/main.css
+++ b/static/main.css
@@ -147,52 +147,58 @@ aside {
 }
 
 .resource-page .resource-section + .resource-section {
-    margin-top: 2rem;
+    margin-top: 1.5rem;
 }
 
 .resource-section {
     border-top: 1px solid #dde5ee;
-    padding-top: 1.25rem;
+    padding-top: 1rem;
 }
 
 .resource-section-title {
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
 }
 
 .resource-group {
-    margin-top: 1.5rem;
+    margin-top: 1rem;
 }
 
 .resource-group-title {
     color: #5c6675;
-    font-size: 1.05rem;
-    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    margin-bottom: 0.45rem;
 }
 
 .resource-list {
-    display: grid;
-    gap: 0.85rem;
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
+.resource-entry + .resource-entry {
+    margin-top: 0.55rem;
+}
+
 .resource-entry {
-    background: #f8fafc;
-    border: 1px solid #d9e1ea;
-    border-radius: 0.5rem;
-    padding: 0.9rem 1rem;
+    border-left: 3px solid #d9e1ea;
+    padding: 0.1rem 0 0.1rem 0.85rem;
+}
+
+.resource-entry-main {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
 }
 
 .resource-entry-title {
-    font-size: 1.02rem;
     font-weight: 600;
-    line-height: 1.35;
+    line-height: 1.3;
 }
 
 .resource-entry-description {
     color: #5c6675;
-    margin: 0.45rem 0 0;
+    margin: 0.2rem 0 0;
 }
 
 .resource-entry-description p {
@@ -202,16 +208,29 @@ aside {
 .resource-entry-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.45rem 0.8rem;
-    margin-top: 0.7rem;
+    gap: 0.25rem 0.45rem;
 }
 
 .resource-entry-links a {
-    background: #eef3f8;
-    border: 1px solid #d6dde6;
-    border-radius: 999px;
-    font-size: 0.92rem;
-    padding: 0.2rem 0.6rem;
+    color: #4f6278;
+    font-size: 0.88rem;
+    text-decoration: none;
+}
+
+.resource-entry-links a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 48em) {
+    .resource-entry {
+        padding-left: 0.75rem;
+    }
+
+    .resource-entry-main {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
 }
 
 li[data-resource-entry][hidden],


### PR DESCRIPTION
## Summary
- replace the bulletin-style resource lists with clearer stacked entry blocks
- separate titles, descriptions, and related links for easier scanning
- strengthen section and group spacing without changing the underlying data model

## Checks
- make build
- git diff --check
