### PR TITLE
feat: collapse resource groups by default

### DIFF
--- a/layouts/_default/resources.html
+++ b/layouts/_default/resources.html
@@ -43,6 +43,7 @@ document.addEventListener("DOMContentLoaded", function () {
   var emptyState = document.querySelector("[data-resource-empty]");
   var sections = Array.prototype.slice.call(document.querySelectorAll("[data-resource-section]"));
   var entries = Array.prototype.slice.call(document.querySelectorAll("[data-resource-entry]"));
+  var groups = Array.prototype.slice.call(document.querySelectorAll("[data-resource-group]"));
   var params = new URLSearchParams(window.location.search);
 
   if (params.has("q")) {
@@ -72,20 +73,29 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     sections.forEach(function (section) {
-      var groups = Array.prototype.slice.call(section.querySelectorAll("[data-resource-group]"));
-      groups.forEach(function (group) {
+      var sectionGroups = Array.prototype.slice.call(section.querySelectorAll("[data-resource-group]"));
+      sectionGroups.forEach(function (group) {
         var groupEntries = Array.prototype.slice.call(group.querySelectorAll("[data-resource-entry]"));
         var hasVisibleEntries = groupEntries.some(function (entry) {
           return !entry.hidden;
         });
         group.hidden = !hasVisibleEntries;
+        if (query !== "" && hasVisibleEntries) {
+          if (!group.open) {
+            group.open = true;
+            group.dataset.autoOpened = "true";
+          }
+        } else if (query === "" && group.dataset.autoOpened === "true") {
+          group.open = false;
+          delete group.dataset.autoOpened;
+        }
       });
 
       var directEntries = Array.prototype.slice.call(section.querySelectorAll(":scope > ul [data-resource-entry]"));
       var hasVisibleDirectEntries = directEntries.some(function (entry) {
         return !entry.hidden;
       });
-      var hasVisibleGroups = groups.some(function (group) {
+      var hasVisibleGroups = sectionGroups.some(function (group) {
         return !group.hidden;
       });
       section.hidden = !(hasVisibleDirectEntries || hasVisibleGroups);
@@ -102,6 +112,13 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   input.addEventListener("input", updateResults);
+  groups.forEach(function (group) {
+    group.addEventListener("toggle", function () {
+      if (input.value.trim() === "") {
+        delete group.dataset.autoOpened;
+      }
+    });
+  });
   input.addEventListener("keydown", function (event) {
     if (event.key === "Escape" && input.value !== "") {
       input.value = "";

--- a/layouts/partials/resource_list.html
+++ b/layouts/partials/resource_list.html
@@ -1,5 +1,5 @@
 {{ with . }}
-<ul>
+<ul class="resource-list">
 {{ range . }}
   {{ $searchText := printf "%s %s" .name (.description | default "") }}
   {{ range (.links | default (slice)) }}

--- a/layouts/partials/resource_section.html
+++ b/layouts/partials/resource_section.html
@@ -3,9 +3,12 @@
 {{ partial "resource_list.html" .resources }}
 {{ $section := .title }}
 {{ range .groups }}
-<div class="resource-group" data-resource-group>
-<h3 id="{{ anchorize (printf "%s-%s" $section .title) }}">{{ .title }}</h3>
+<details class="resource-group" id="{{ anchorize (printf "%s-%s" $section .title) }}" data-resource-group>
+<summary>
+  <span class="resource-group-title">{{ .title }}</span>
+  <span class="resource-group-count">{{ len (.resources | default (slice)) }}</span>
+</summary>
   {{ partial "resource_list.html" .resources }}
-  </div>
+</details>
 {{ end }}
   </section>

--- a/static/main.css
+++ b/static/main.css
@@ -189,7 +189,55 @@ aside {
 }
 
 .resource-group {
+    border: 1px solid #d6dde6;
+    border-radius: 0.5rem;
     margin-top: 1rem;
+    overflow: hidden;
+}
+
+.resource-group summary {
+    align-items: center;
+    background: #f5f8fb;
+    cursor: pointer;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    list-style: none;
+    margin: 0;
+    padding: 0.8rem 1rem;
+}
+
+.resource-group summary::-webkit-details-marker {
+    display: none;
+}
+
+.resource-group summary:hover {
+    background: #eef3f8;
+}
+
+.resource-group summary:focus {
+    outline: 2px solid #7aa7d8;
+    outline-offset: -2px;
+}
+
+.resource-group-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+
+.resource-group-count {
+    background: #dfe8f2;
+    border-radius: 999px;
+    color: #465364;
+    flex: 0 0 auto;
+    font-size: 0.85rem;
+    line-height: 1;
+    padding: 0.3rem 0.55rem;
+}
+
+.resource-group .resource-list {
+    margin: 0;
+    padding: 0.85rem 1.25rem 1rem 2.5rem;
 }
 
 li[data-resource-entry][hidden],


### PR DESCRIPTION
## Summary
- collapse grouped resource subsections behind clickable summaries
- show per-group entry counts to make scanning easier
- auto-expand matching groups while a search filter is active

## Testing
- make build